### PR TITLE
Change default tricera path to assume that tri is in $PATH

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,15 +24,15 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - run: |
+          sudo apt-get update
+          sudo apt-get install -q -y graphviz libgtk-3-dev libgtksourceview-3.0-dev
       - name: Checkout tree
         uses: actions/checkout@v4
       - name: Set-up OCaml ${{ matrix.ocaml-compiler }}
         uses: ocaml/setup-ocaml@v2
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
-      - run: |
-          sudo apt-get update
-          sudo apt-get install graphviz libgtk-3-dev libgtksourceview-3.0-dev
       - run: |
           opam install . --deps-only --with-test
           opam exec -- dune build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,10 @@ jobs:
         uses: ocaml/setup-ocaml@v2
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
-      - run: opam install . --deps-only --with-test
-      - run: opam exec -- dune build
-      - run: opam exec -- dune runtest
+      - run: |
+          sudo apt-get update
+          sudo apt-get install graphviz libgtk-3-dev libgtksourceview-3.0-dev
+      - run: |
+          opam install . --deps-only --with-test
+          opam exec -- dune build
+          opam exec -- dune runtest

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This program is licensed under the GPL2 license, see license headers in source c
 and the full license in the LICENSE file.
 
 ACSL Contract inference for helper functions.
-Developed for Frama-C v23.1 but also seems to work for v24.  
+Developed for Frama-C v23.1 but also seems to work for Frama-C versions <= 28.1.
 Please note that the plugin is experimental and still under development so that no results are guaranteed.
 
 

--- a/src/options_saida.ml
+++ b/src/options_saida.ml
@@ -44,7 +44,7 @@ module Output_file = Self.String
 module Tricera_path = Self.String
   (struct
     let option_name = "-saida-tricera-path"
-    let default = "~/Documents/tricera/tri"
+    let default = "tri"
     let arg_name = "output_file"
     let help = "Sets the path to the TriCera executable"
   end)


### PR DESCRIPTION
This PR modifies the default for option `-saida-tricera-path` to `tri`. Effectively this assumes that `tri` is in scope of `$PATH`. This is a more convenient default than `~/Documents/tricera/tri` since it can easily be achieved by either adding to `$PATH` or setting up symlinks.