### PR TITLE
Frama c29

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ This program is licensed under the GPL2 license, see license headers in source c
 and the full license in the LICENSE file.
 
 This is a plugin for Frama-C. Given ab entry-point function with an ACSL contract, it infers
-ACSL contracts for helper functions, i.e. functions further down the call tree. It was
-originally developed for Frama-C v23.1 but has been tested with Frama-C versions <= 28.1.
+ACSL contracts for helper functions, i.e. functions further down the call tree. Current version
+has been tested with Frama-C v29.
 Please note that the plugin is experimental and still under development so that no results
 are guaranteed.
 
 
-## Install TriCera  
+## Install TriCera
 This plugin requires TriCera to be installed on your system, see:  
 https://github.com/uuverifiers/tricera  
 
@@ -19,16 +19,13 @@ https://github.com/uuverifiers/tricera
 
 * Installation:  
 Register as plug-in using these commands (Ubuntu):
-
-	* For Frama-C version <= 25:
-```make; make install```
-	* For Frama-C version 26 and onward:
 ```dune build @install && dune install```
 
 * Execution:  
 Run the plugin on file test.c as: 
 ```frama-c -saida -saida-tricera-path <path-to-tricera> test.c```  
-where path-to-tricera is the path to the TriCera executable (tri). If no path is provided, defaults to `~/Documents/tricera/tri`
+where path-to-tricera is the path to the TriCera executable (tri). If no path is
+provided, the plugin will use `tri` in `$PATH`.
 
 * Lib-entry option:  
 Optionally, use the Frama-C lib-entry option to non-deterministically assign all global

--- a/dune-project
+++ b/dune-project
@@ -14,8 +14,8 @@
 (package 
   (name frama-c-saida)
  (depends
-  (ocaml (>= 4.14))
-  (frama-c (>= 26)))
+  (ocaml (>= 4.13.1))
+  (frama-c (>= 29)))
  (synopsis "ACSL contract inference for helper functions")
  (description "This plugin for the Frama-C platform for source code analysis
 of C programs provides inference of ACSL contracts for helper functions."))

--- a/frama-c-saida.opam
+++ b/frama-c-saida.opam
@@ -12,8 +12,8 @@ homepage: "https://github.com/rse-verification/saida"
 bug-reports: "https://github.com/rse-verification/saida/issues"
 depends: [
   "dune" {>= "3.2"}
-  "ocaml" {>= "4.14"}
-  "frama-c" {>= "26"}
+  "ocaml" {>= "4.13.1"}
+  "frama-c" {>= "29"}
   "odoc" {with-doc}
 ]
 build: [

--- a/src/main.ml
+++ b/src/main.ml
@@ -171,4 +171,4 @@ let run () =
     let msg = Printexc.to_string exc in
       Printf.eprintf "There was an error: %s\n" msg
 
-let () = Db.Main.extend run
+let () = Boot.Main.extend run

--- a/src/saida_vis.ml
+++ b/src/saida_vis.ml
@@ -526,7 +526,7 @@ let make_harness_func f_svar behavs =
   in
   {
     (* name = Printf.sprintf "%s_harness" f_name; *)
-    name = Kernel.MainFunction.get ();
+    name = "main";
     block = h_block;
     assumes = assumes;
     asserts = asserts;

--- a/src/saida_vis.ml
+++ b/src/saida_vis.ml
@@ -291,7 +291,7 @@ let rec bounded_vars_term term =
   | TSizeOfE t
   | TAlignOfE t
   | TUnOp (_,t)
-  | TCastE (_,t)
+  | TCast (_,_,t)
   | Tat (t,_)
   | Toffset (_,t)
   | Tbase_addr (_,t)
@@ -363,7 +363,7 @@ let rec bounded_vars_term term =
     let b_bv = bounded_vars_term b
     in
     Logic_var.Set.union d_bv b_bv
-  | TLogic_coerce(_,t) -> bounded_vars_term t
+  (* | TLogic_coerce(_,t) -> bounded_vars_term t *)
 
 
 and bounded_vars_lval (h,o) =
@@ -635,7 +635,7 @@ let term_node_debug_print out tn =
         | TAlignOfE (_) -> Format.fprintf out "5" (** alignment of the type of an expression. *)
         | TUnOp (_, _) -> Format.fprintf out "6" (** unary operator. *)
         | TBinOp (_, _, _) -> Format.fprintf out "7" (** binary operators. *)
-        | TCastE (_, _) -> Format.fprintf out "8" (** cast to a C type. *)
+        | TCast (_,_, _) -> Format.fprintf out "8" (** cast to a C type. *)
         | TAddrOf (_) -> Format.fprintf out "9" (** address of a term. *)
         | TStartOf (_) -> Format.fprintf out "10" (** beginning of an array. *)
 
@@ -653,7 +653,7 @@ let term_node_debug_print out tn =
         | Toffset (_, _) -> Format.fprintf out "17" (** offset from the base address of a pointer. *)
         | Tblock_length (_, _) -> Format.fprintf out "18" (** length of the block pointed to by the term. *)
         | Tnull -> Format.fprintf out "19"(** the null pointer. *)
-        | TLogic_coerce (lt, term) -> Format.fprintf out "19";
+        (* | TLogic_coerce (lt, term) -> Format.fprintf out "19"; *)
           (* logic_type_to_tla out lt *)
         (** implicit conversion from a C type to a logic type.
             The logic type must not be a Ctype. In particular, used to denote
@@ -998,8 +998,8 @@ class acsl2tricera out = object (self)
 
     (*Print assumes for special ghost-var ensures*)
     (*experimental feature*)
-    self#print_special_ghost_ensure_assumes hf;
-    self#print_newline;
+    (* self#print_special_ghost_ensure_assumes hf;
+    self#print_newline; *)
 
     (*Print the function call to the function we are harness for*)
     self#print_line "//Function call that the harness function verifies";
@@ -1142,8 +1142,8 @@ class acsl2tricera out = object (self)
         | TDataCons(lci, terms) ->
           self#print_string "logic_sum_types_not_supported"
           (* Format.fprintf out "%a" Printer.pp_logic_ctor_info lci; *)
-        | TLogic_coerce (_, t) ->
-          ignore ( Cil.visitCilTerm (self :> Cil.cilVisitor) t);
+        (* | TLogic_coerce (_, t) ->
+          ignore ( Cil.visitCilTerm (self :> Cil.cilVisitor) t); *)
         | Tat(t, ll) ->
           if is_old_or_pre_logic_label ll then
             begin
@@ -1155,7 +1155,7 @@ class acsl2tricera out = object (self)
             begin
               self#print_string "Currently only old/pre logic labels supported" ;
             end
-        | TCastE(_, t) ->
+        | TCast(_, _, t) ->
           ignore ( Cil.visitCilTerm (self :> Cil.cilVisitor) t);
         | Tlet(b, t) ->
           self#add_let_var_def b;


### PR DESCRIPTION
Upgrades to support frama-c v29. Includes some updates of pattern matching due to updates in the Frama-C AST. Also to use the new boot API used in >= 29. 