### PR TITLE
Implement output filename option

### DIFF
--- a/src/options_saida.ml
+++ b/src/options_saida.ml
@@ -34,9 +34,9 @@ module Self = Plugin.Register
 module Output_file = Self.String
   (struct
     let option_name = "-saida-out"
-    let default = "saida_out.c"
+    let default = "saida.out"
     let arg_name = "output_file"
-    let help = "File to save harness function for the contract"
+    let help = "Name of file to store the source code with inferred contracts in."
   end)
 
 
@@ -45,7 +45,7 @@ module Tricera_path = Self.String
   (struct
     let option_name = "-saida-tricera-path"
     let default = "tri"
-    let arg_name = "output_file"
+    let arg_name = "tricera_path"
     let help = "Sets the path to the TriCera executable"
   end)
 

--- a/src/tricera2acsl.ml
+++ b/src/tricera2acsl.ml
@@ -24,7 +24,6 @@ open Options_saida
 
 let harness_source_merged_fname = "tmp_harness_source_merged.c"
 let tricera_output_name = "tmp_tricera_result.txt"
-let inferred_source_merged_fname = "tmp_inferred_source_merged.c"
 
 let try_read ic =
     try Some (input_line ic) with End_of_file -> None


### PR DESCRIPTION
There exists a command line option for setting the output filename. However, this option is currently ignored by the implementation. This PR implements the option machinery fully to allow for the user to select the filename of the saida result.