### PR TITLE
Use explicit frama-c image in workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,8 @@ jobs:
         uses: actions/checkout@v4
         
       - run: |
-          opam init --shell-setup
+          chown -R opam:opam .
+          su - opam
           eval $(opam env)
           opam install . --deps-only --with-test
           opam exec -- dune build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,8 @@ jobs:
           - framac/frama-c:31.0
 
     runs-on: ${{ matrix.os }}
-    image: ${{ matrix.frama-c-image }}
+    container:
+      image: ${{ matrix.frama-c-image }}
 
     steps:
       - name: Checkout tree

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - '**'
+  workflow_dispatch:
 
 permissions: read-all
 
@@ -17,20 +18,15 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-        ocaml-compiler:
-          - "4.13.1"
-          - "5.1"
+        frama-c-image:
+          - framac/frama-c:31.0
 
     runs-on: ${{ matrix.os }}
+    image: ${{ matrix.frama-c-image }}
 
     steps:
       - name: Checkout tree
         uses: actions/checkout@v4
-
-      - name: Set-up OCaml ${{ matrix.ocaml-compiler }}
-        uses: ocaml/setup-ocaml@v3
-        with:
-          ocaml-compiler: ${{ matrix.ocaml-compiler }}
       - run: |
           opam install . --deps-only --with-test
           opam exec -- dune build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,8 +29,10 @@ jobs:
     steps:
       - name: Checkout tree
         uses: actions/checkout@v4
-
+        
       - run: |
+          opam init --shell-setup
+          eval $(opam env)
           opam install . --deps-only --with-test
           opam exec -- dune build
           opam exec -- dune runtest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,10 +24,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     container:
       image: ${{ matrix.frama-c-image }}
+      options: --user root
 
     steps:
       - name: Checkout tree
         uses: actions/checkout@v4
+
       - run: |
           opam install . --deps-only --with-test
           opam exec -- dune build


### PR DESCRIPTION
Building the module takes a unnecessarily  long time (~8 min). Most of that time is spent on installing opam and frama-c in the workflow. This PR changes the workflow to use an official frama-c container image instead.