### PR TITLE
fix: Avoid printing id when printing predicates for assume/assert

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ and the full license in the LICENSE file.
 
 This is a plugin for Frama-C. Given ab entry-point function with an ACSL contract, it infers
 ACSL contracts for helper functions, i.e. functions further down the call tree. Current version
-has been tested with Frama-C v29.
+has been tested with Frama-C v31.
 Please note that the plugin is experimental and still under development so that no results
 are guaranteed.
 
@@ -22,7 +22,6 @@ https://github.com/uuverifiers/tricera
 * Installation:  
 Register as plug-in using these commands (Ubuntu):
 ```dune build @install && dune install```
-	* NOTE: For Frama-C version >= 29: Use branch framac29
 
 * Execution:  
 Run the plugin on file test.c as: 
@@ -49,7 +48,8 @@ The plugin is currently limited to programs/specifications following these rules
 * Any non-main function should _not_ contain a contract.
   I.e., only 1 contract allowed in the file.
 * The non-main functions has to be called somewhere from within the file
-* Currently does not support arrays, floating points, or stack pointers.
+* Currently does not support floating points.
+* Partial support for arrays and stack pointers.
 * Heap pointers are generally supported (but bugs exist in some cases in the translation to ACSL).
 * Does not support inference of contracts for functions with local static variables.
 * In the ACSL contract, only ensures and requires clauses over C expressions are support, with the exception of certain uses of quantification: universal quantification is supported in the post-conditions, and existential quantification in the pre-condition. 
@@ -61,7 +61,10 @@ Aside from the limitations listed above, many more limitations/bugs expected to 
 ## *Summary*  
 The execution of the plugin can be summarized as:  
 Step 1: convert the top-level contract to a TriCera harness function  
-Step 2: Merge the harness function with the source code (this result is stored in `tmp_harness_source_merged.c`)  
-Step 3: Run tricera on the result from step 2  
-Step 4: Merge the inferred contracts from step 3 with the source code (this result is stored in `tmp_inferred_source_merged.c`)  
+Step 2: Merge the harness function with the source code 
+  (this result is stored in `/tmp/saida_harness_<file-name>.c`)  
+Step 3: Run tricera on the result from step 2
+  (this result is stored in `/tmp/saida_result_<file-name>.c`)
+Step 4: Merge the inferred contracts from step 3 with the source code
+  (this result is stored in `saida.out` or file given by `-saida-out=<file>` option)  
 Step 5: (optional) Run the wp plugin on the result from step 4

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 This program is licensed under the GPL2 license, see license headers in source code files
 and the full license in the LICENSE file.
 
-This is a plugin for Frama-C. Given ab entry-point function with an ACSL contract, it infers
+This is a plugin for Frama-C. Given an entry-point function with an ACSL contract, it infers
 ACSL contracts for helper functions, i.e. functions further down the call tree. Current version
 has been tested with Frama-C v31.
 Please note that the plugin is experimental and still under development so that no results
@@ -13,7 +13,7 @@ are guaranteed.
 
 
 ## Install TriCera
-This plugin requires TriCera to be installed on your system, see:  
+This plugin requires TriCera to be installed on your system, see: 
 https://github.com/uuverifiers/tricera  
 
 
@@ -40,31 +40,35 @@ Use the *-saida-wp* option for running the -wp plugin to verify the inferred con
   ```frama-c -saida -saida-tricera-path <path-to-tricera> -saida-wp test.c```
 
 
-## Limitations
-The plugin is currently limited to programs/specifications following these rules:
-* Only one main function, with return type void.s
-* The main function should contain a top-level contract containing a requires
-  clause and an ensures clause.
-* Any non-main function should _not_ contain a contract.
-  I.e., only 1 contract allowed in the file.
-* The non-main functions has to be called somewhere from within the file
-* Currently does not support floating points.
-* Partial support for arrays and stack pointers.
-* Heap pointers are generally supported (but bugs exist in some cases in the translation to ACSL).
-* Does not support inference of contracts for functions with local static variables.
-* In the ACSL contract, only ensures and requires clauses over C expressions are support, with the exception of certain uses of quantification: universal quantification is supported in the post-conditions, and existential quantification in the pre-condition. 
-  Other types of ACSL built-in or user defined constructs, such as logical functions and predicates, are not supported.
-  
-
-Aside from the limitations listed above, many more limitations/bugs expected to exist.  
-
-## *Summary*  
+### Summary
 The execution of the plugin can be summarized as:  
 Step 1: convert the top-level contract to a TriCera harness function  
 Step 2: Merge the harness function with the source code 
   (this result is stored in `/tmp/saida_harness_<file-name>.c`)  
 Step 3: Run tricera on the result from step 2
-  (this result is stored in `/tmp/saida_result_<file-name>.c`)
+  (this result is stored in `/tmp/saida_result_<file-name>.c`)  
 Step 4: Merge the inferred contracts from step 3 with the source code
   (this result is stored in `saida.out` or file given by `-saida-out=<file>` option)  
 Step 5: (optional) Run the wp plugin on the result from step 4
+
+## Development
+
+A suitable development environment for the plugin is provided by the
+[AutoDeduct toolchain docker image](https://github.com/rse-verification/auto-deduct-toolchain).
+
+## Limitations
+The plugin is currently limited to programs/specifications following these rules:
+* The entry-point function should contain a top-level contract containing a requires
+  clause and an ensures clause.
+* The non-entry-point functions has to be called somewhere from within the file
+* Currently does not support floating points.
+* Partial support for arrays and stack pointers.
+* Heap pointers are generally supported (but bugs exist in some cases in the translation to ACSL).
+* Does not support inference of contracts for functions with local static variables.
+* In the ACSL contract, only ensures and requires clauses over C expressions are support,
+  with the exception of certain uses of quantification: universal quantification is supported in
+  the post-conditions, and existential quantification in the pre-condition. Other types of ACSL
+  built-in or user defined constructs, such as logical functions and predicates, are not supported.
+  
+Aside from the limitations listed above, many more limitations/bugs expected to exist.  
+

--- a/src/main.ml
+++ b/src/main.ml
@@ -173,7 +173,7 @@ let run () =
     let fmt = Format.formatter_of_buffer harness_buff in
     Format.pp_set_margin fmt max_int;
     let pt = new tricera_print fmt in
-    pt#print_harness_function (List.hd(hf_list));
+    pt#print_harness_function (List.find (fun i -> i.name == (Kernel.MainFunction.get_function_name ())) hf_list);
     let _ = Format.pp_print_flush fmt () in
 
     let output_fname = OutputFile.get () in

--- a/src/saida_vis.ml
+++ b/src/saida_vis.ml
@@ -507,7 +507,8 @@ let make_harness_func fdec behavs =
     | TFun(r, _, _) -> r
     | _ -> fdec.svar.vtype (*shouldnt happen*)
   in
-  { name = "main" (* FIX ME: Should use a proper harness function name *)
+  { name = fdec.svar.vorig_name
+    (* FIX ME: Should use a proper harness function name *)
     (* name = Printf.sprintf "%s_harness" f_name; *)
   ; block = h_block
   ; assumes = assumes
@@ -631,7 +632,13 @@ class tricera_print out = object (self)
   method private print_newline = Format.fprintf out "@,"
 
   method private print_harness_fn_name fmt hf =
-    Format.fprintf fmt "void %s()" hf.name
+    (*
+       TODO: Should probably use some more intelligent name. 
+         Fix this when fixing implementing function argument support.
+         See tests/basic/func_arguments.c
+    *)
+    (* Format.fprintf fmt "void %s()" *)
+    Format.fprintf fmt "void main()"
 
   method private print_require_assumes hf =
     match hf.assumes with

--- a/src/saida_vis.ml
+++ b/src/saida_vis.ml
@@ -640,7 +640,8 @@ class tricera_print out = object (self)
       Format.fprintf out "//The requires-clauses translated into assumes@,";
       List.iter
         (fun ip ->
-          Format.fprintf out "assume(%a);@," Printer.pp_identified_predicate ip)
+          Format.fprintf out "assume(%a);@," 
+            Printer.pp_predicate_node ip.ip_content.tp_statement.pred_content)
         assumes
 
   method private print_special_ghost_ensure_assumes hf =
@@ -650,7 +651,8 @@ class tricera_print out = object (self)
       Format.fprintf out "//Special assumes of ghost-variables 'assigned to' in requires clause@,";
       List.iter
         (fun ip ->
-          Format.fprintf out "assume(%a);@," Printer.pp_identified_predicate ip)
+          Format.fprintf out "assume(%a);@,"
+            Printer.pp_predicate_node ip.ip_content.tp_statement.pred_content)
         ghosts
 
   method private print_ensure_asserts hf =
@@ -660,7 +662,8 @@ class tricera_print out = object (self)
       Format.fprintf out "//The ensures-clauses translated into asserts@,";
       List.iter
         (fun ip -> 
-          Format.fprintf out "assert(%a);@," Printer.pp_identified_predicate ip)
+          Format.fprintf out "assert(%a);@,"
+            Printer.pp_predicate_node ip.ip_content.tp_statement.pred_content)
         asserts
 
   method private print_log_var_decls hf =

--- a/src/saida_vis.ml
+++ b/src/saida_vis.ml
@@ -508,8 +508,6 @@ let make_harness_func fdec behavs =
     | _ -> fdec.svar.vtype (*shouldnt happen*)
   in
   { name = fdec.svar.vorig_name
-    (* FIX ME: Should use a proper harness function name *)
-    (* name = Printf.sprintf "%s_harness" f_name; *)
   ; block = h_block
   ; assumes = assumes
   ; asserts = asserts

--- a/tests/basic/let.c
+++ b/tests/basic/let.c
@@ -1,6 +1,6 @@
 /* run.config
    LOG: saida_harness_@PTEST_NAME@.c
-   OPT: -lib-entry -saida -saida-tricera-opts="-acsl" -saida-keep-tmp -saida-out=@PTEST_NAME@.out.c
+   OPT: -lib-entry -main=f -saida -saida-tricera-opts="-acsl" -saida-keep-tmp -saida-out=@PTEST_NAME@.out.c
 */
 /*
   This test makes sure that \let clauses are translated properly.

--- a/tests/basic/let.c
+++ b/tests/basic/let.c
@@ -3,7 +3,8 @@
    OPT: -lib-entry -saida -saida-tricera-opts="-acsl" -saida-keep-tmp -saida-out=@PTEST_NAME@.out.c
 */
 /*
-  This test makes sure that \let clauses are translated properly. 
+  This test makes sure that \let clauses are translated properly.
+  See example 2.31 in "ANSI/ISO C Specification Language  Version 1.22"
   TODO: Not yet supported.
 */
 

--- a/tests/basic/let2.c
+++ b/tests/basic/let2.c
@@ -1,6 +1,6 @@
 /* run.config
    LOG: saida_harness_@PTEST_NAME@.c
-   OPT: -lib-entry -saida -saida-tricera-opts="-acsl" -saida-keep-tmp -saida-out=@PTEST_NAME@.out.c
+   OPT: -lib-entry -main=f -saida -saida-tricera-opts="-acsl" -saida-keep-tmp -saida-out=@PTEST_NAME@.out.c
 */
 /*
   This test makes sure that \let with pointers are translated properly. 

--- a/tests/basic/oracle/let.err.oracle
+++ b/tests/basic/oracle/let.err.oracle
@@ -1,3 +1,3 @@
-Syntax Error, trying to recover and continue parse... for input symbol "" spanning from unknown:14/14(319) to unknown:14/15(320)
+Syntax Error, trying to recover and continue parse... for input symbol "" spanning from unknown:15/14(390) to unknown:15/15(391)
 Warning: The input program could not be parsed. If 'main' is not the entry point to
 the program, use the option '-m:entry-function-name' to specify the entry point.

--- a/tests/basic/oracle/let.err.oracle
+++ b/tests/basic/oracle/let.err.oracle
@@ -1,3 +1,3 @@
-Syntax Error, trying to recover and continue parse... for input symbol "" spanning from unknown:15/14(390) to unknown:15/15(391)
+Syntax Error, trying to recover and continue parse... for input symbol "" spanning from unknown:15/14(398) to unknown:15/15(399)
 Warning: The input program could not be parsed. If 'main' is not the entry point to
 the program, use the option '-m:entry-function-name' to specify the entry point.

--- a/tests/basic/oracle/let2.err.oracle
+++ b/tests/basic/oracle/let2.err.oracle
@@ -1,3 +1,3 @@
-Syntax Error, trying to recover and continue parse... for input symbol "" spanning from unknown:14/14(336) to unknown:14/15(337)
+Syntax Error, trying to recover and continue parse... for input symbol "" spanning from unknown:14/14(344) to unknown:14/15(345)
 Warning: The input program could not be parsed. If 'main' is not the entry point to
 the program, use the option '-m:entry-function-name' to specify the entry point.

--- a/tests/basic/oracle/saida_harness_let.c
+++ b/tests/basic/oracle/saida_harness_let.c
@@ -1,6 +1,6 @@
 /* run.config
    LOG: saida_harness_@PTEST_NAME@.c
-   OPT: -lib-entry -saida -saida-tricera-opts="-acsl" -saida-keep-tmp -saida-out=@PTEST_NAME@.out.c
+   OPT: -lib-entry -main=f -saida -saida-tricera-opts="-acsl" -saida-keep-tmp -saida-out=@PTEST_NAME@.out.c
 */
 /*
   This test makes sure that \let clauses are translated properly.
@@ -15,7 +15,6 @@ int t[10];
 int any(void);
 
 
-/*@contract@*/
 void f() {
   i = any();
   t[i]++;

--- a/tests/basic/oracle/saida_harness_let.c
+++ b/tests/basic/oracle/saida_harness_let.c
@@ -3,7 +3,8 @@
    OPT: -lib-entry -saida -saida-tricera-opts="-acsl" -saida-keep-tmp -saida-out=@PTEST_NAME@.out.c
 */
 /*
-  This test makes sure that \let clauses are translated properly. 
+  This test makes sure that \let clauses are translated properly.
+  See example 2.31 in "ANSI/ISO C Specification Language  Version 1.22"
   TODO: Not yet supported.
 */
 

--- a/tests/basic/oracle/saida_harness_let2.c
+++ b/tests/basic/oracle/saida_harness_let2.c
@@ -1,6 +1,6 @@
 /* run.config
    LOG: saida_harness_@PTEST_NAME@.c
-   OPT: -lib-entry -saida -saida-tricera-opts="-acsl" -saida-keep-tmp -saida-out=@PTEST_NAME@.out.c
+   OPT: -lib-entry -main=f -saida -saida-tricera-opts="-acsl" -saida-keep-tmp -saida-out=@PTEST_NAME@.out.c
 */
 /*
   This test makes sure that \let with pointers are translated properly. 
@@ -14,7 +14,6 @@ int *p = t;
 int any(void);
 
 
-/*@contract@*/
 void f() {
   i = any();
   *(p+i) += 1;


### PR DESCRIPTION
This PR makes sure that the name of identified predicates is not printed when printing assume/assert statements in the harness function.

It also makes sure to print the correct harness function based on the function name given by the Frama-C option `-main=...` 